### PR TITLE
Remove reference to 20 pound webhooks

### DIFF
--- a/source/docs/01_overview/05_support/02_troubleshooting.md
+++ b/source/docs/01_overview/05_support/02_troubleshooting.md
@@ -6,7 +6,6 @@
 - [The payment page says 400 error: "Redirect uri does not match the uri registered in the developer panel"](#redirect-invalid)
 - [The payment page begins https://sandbox.gocardless.com but I want to use the live environment](#switch-env)
 - [My payments are not getting confirmed](#confirm-failure)
-- [My testing bill webhook says amount = £20](#webhook-20)
 - [Something else is broken](#exception-handling)
 
 
@@ -50,12 +49,6 @@ Firstly, please ensure that you are attempting to confirm your payment on the re
 Secondly, ensure that you have the correct developer credentials and environment set up on your confirmation page. If you are trying to create payments in the live environment, but you are attempting to confirm using sandbox environment or developer credentials, you will run into an error.
 
 If you payments still fail to confirm, try catching the exception thrown by the GoCardless library when running the confirm function. More details [here](#exception-handling).
-
-
-### <a name="webhook-20"></a>My testing bill webhook says amount = £20
-All test webhooks are created from a template, so the amount will always equal £20. The resource ID, source ID and status will be set to those given in the webhook tester.
-
-For more information on testing webhooks, please see the [testing webhooks section](#testing-webhooks).
 
 
 ### <a name="exception-handling"></a>Something else is broken

--- a/source/docs/02_api_libraries/03_webhooks/04_testing_webhooks.js.md
+++ b/source/docs/02_api_libraries/03_webhooks/04_testing_webhooks.js.md
@@ -2,8 +2,6 @@
 
 To test that you're receiving webhooks correctly, you should use the GoCardless webhook tester. This is an incredibly useful feature that lets you send test webhooks from GoCardless, rather than waiting for an actual event in your GoCardless account.
 
-In the 'WebHooks' section of your developer page, click 'Send web hook' in the top right hand corner. You should check that the 'Web hook URL' field matches the page that your would like your webhooks sent to. You should then choose the resource type for the webhook, the ID for that resource and a source ID if appropriate (for example, the source ID for a bill might be the subscription that created that bill). 
-
-Please note that test webhooks will always contain an `amount` value of £20.
+In the 'WebHooks' section of your developer page, click 'Send web hook' in the top right hand corner. You should check that the 'Web hook URL' field matches the page that your would like your webhooks sent to. You should then choose the resource type for the webhook, the ID for that resource and a source ID if appropriate (for example, the source ID for a bill might be the subscription that created that bill).
 
 Once your webhook is sent, you should see it appear in the developer panel with a status of 200. You can click on the webhook to get more information, including the response that your server sent.

--- a/source/docs/02_api_libraries/03_webhooks/04_testing_webhooks.php.md
+++ b/source/docs/02_api_libraries/03_webhooks/04_testing_webhooks.php.md
@@ -2,8 +2,6 @@
 
 To test that you're receiving webhooks correctly, you should use the GoCardless webhook tester. This is an incredibly useful feature that lets you send test webhooks from GoCardless, rather than waiting for an actual event in your GoCardless account.
 
-In the 'WebHooks' section of your developer page, click 'Send web hook' in the top right hand corner. You should check that the 'Web hook URL' field matches the page that your would like your webhooks sent to. You should then choose the resource type for the webhook, the ID for that resource and a source ID if appropriate (for example, the source ID for a bill might be the subscription that created that bill). 
-
-Please note that test webhooks will always contain an `amount` value of £20.
+In the 'WebHooks' section of your developer page, click 'Send web hook' in the top right hand corner. You should check that the 'Web hook URL' field matches the page that your would like your webhooks sent to. You should then choose the resource type for the webhook, the ID for that resource and a source ID if appropriate (for example, the source ID for a bill might be the subscription that created that bill).
 
 Once your webhook is sent, you should see it appear in the developer panel with a status of 200. You can click on the webhook to get more information, including the response that your server sent.

--- a/source/docs/02_api_libraries/03_webhooks/04_testing_webhooks.py.md
+++ b/source/docs/02_api_libraries/03_webhooks/04_testing_webhooks.py.md
@@ -2,8 +2,6 @@
 
 To test that you're receiving webhooks correctly, you should use the GoCardless webhook tester. This is an incredibly useful feature that lets you send test webhooks from GoCardless, rather than waiting for an actual event in your GoCardless account.
 
-In the 'WebHooks' section of your developer page, click 'Send web hook' in the top right hand corner. You should check that the 'Web hook URL' field matches the page that your would like your webhooks sent to. You should then choose the resource type for the webhook, the ID for that resource and a source ID if appropriate (for example, the source ID for a bill might be the subscription that created that bill). 
-
-Please note that test webhooks will always contain an `amount` value of £20.
+In the 'WebHooks' section of your developer page, click 'Send web hook' in the top right hand corner. You should check that the 'Web hook URL' field matches the page that your would like your webhooks sent to. You should then choose the resource type for the webhook, the ID for that resource and a source ID if appropriate (for example, the source ID for a bill might be the subscription that created that bill).
 
 Once your webhook is sent, you should see it appear in the developer panel with a status of 200. You can click on the webhook to get more information, including the response that your server sent.

--- a/source/docs/02_api_libraries/03_webhooks/04_testing_webhooks.rb.md
+++ b/source/docs/02_api_libraries/03_webhooks/04_testing_webhooks.rb.md
@@ -2,8 +2,6 @@
 
 To test that you're receiving webhooks correctly, you should use the GoCardless webhook tester. This is an incredibly useful feature that lets you send test webhooks from GoCardless, rather than waiting for an actual event in your GoCardless account.
 
-In the 'WebHooks' section of your developer page, click 'Send web hook' in the top right hand corner. You should check that the 'Web hook URL' field matches the page that your would like your webhooks sent to. You should then choose the resource type for the webhook, the ID for that resource and a source ID if appropriate (for example, the source ID for a bill might be the subscription that created that bill). 
-
-Please note that test webhooks will always contain an `amount` value of £20.
+In the 'WebHooks' section of your developer page, click 'Send web hook' in the top right hand corner. You should check that the 'Web hook URL' field matches the page that your would like your webhooks sent to. You should then choose the resource type for the webhook, the ID for that resource and a source ID if appropriate (for example, the source ID for a bill might be the subscription that created that bill).
 
 Once your webhook is sent, you should see it appear in the developer panel with a status of 200. You can click on the webhook to get more information, including the response that your server sent.


### PR DESCRIPTION
**DO NOT MERGE**

We should start sending test webhooks that pick up the actual amount of a bill (if given its ID). There's a PR on GoCardless to do so - once it's merged we no longer need this caveat.
