### PR TITLE
adding google tag manager

### DIFF
--- a/source/layouts/layout.html.erb
+++ b/source/layouts/layout.html.erb
@@ -102,16 +102,14 @@
     <% end %>
 
     <!-- Google Tag Manager -->
-    <noscript>
-      <iframe src="//www.googletagmanager.com/ns.html?id=GTM-PRFKNC" height="0" width="0" style="display:none;visibility:hidden"></iframe>
-    </noscript>
     <script>
-      (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-      new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-      j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-      '//www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-      })(window,document,'script','dataLayer','GTM-PRFKNC');
+      dataLayer = [];
+    </script>
+    <script src="//www.googletagmanager.com/gtm.js?id=GTM-PRFKNC" async></script>
+    <script>
+      (function(w,l){w[l]=w[l]||[];w[l].push({'gtm.start':new Date().getTime(),event:'gtm.js'});})(window, 'dataLayer');
     </script>
     <!-- End Google Tag Manager -->
+
   </body>
 </html>


### PR DESCRIPTION
@harrison ok to review?

We want to add google tag manager to the API docs so we can add the mixpanel people property "API intent" to people that visit them (so we can send better targeted emails to people interested in the API). I plan to fire "Mixpanel Script", "Mixpanel Pageview - Location Pathname" and "Mixpanel - View API Docs" tags on the API docs.
