### PR TITLE
Link to Enterprise API docs

### DIFF
--- a/source/docs/01_overview/01_introduction.md
+++ b/source/docs/01_overview/01_introduction.md
@@ -11,3 +11,11 @@
 1. To start using our API, you'll need to [sign up for a merchant account](https://gocardless.com/merchants/new)
 2. Enable **developer mode** within your dashboard under the 'More...' tab
 3. Start using one of our [API libraries](/#api-libraries) for your chosen programming language
+
+
+<p class="well-notice u-margin-Vl">
+<strong>Note:</strong> This is the documentation for our Basic API. If you are
+already familar with Direct Debit and take over 500 payments a month you might
+also want to check out our
+<a href="https://developer.gocardless.com/enterprise">Enterprise API</a>.
+</p>

--- a/source/stylesheets/components/well-notice.scss
+++ b/source/stylesheets/components/well-notice.scss
@@ -1,0 +1,5 @@
+.well-notice {
+  padding: 7px 10px;
+  background: #fffef1;
+  border: 1px solid #e5e2c8;
+}


### PR DESCRIPTION
The Enterprise API is more appropriate for any large customers considering GoCardless. We should link to the docs from the introduction.

![link](https://cloud.githubusercontent.com/assets/1144873/4535540/818f4e08-4db5-11e4-8da2-6375f2c6552a.png)
