### PR TITLE
newlines at start and end of example.http files are now removed during gulp build process

### DIFF
--- a/tasks/gulp-highlight.js
+++ b/tasks/gulp-highlight.js
@@ -16,6 +16,8 @@ module.exports = function () {
     }
 
     var content = file.contents.toString();
+    content = content.replace(/(^\n*|\n*$)/g, '');
+
     var suffix = path.extname(file.path).replace('.', '');
     var langs = {
       cs: 'csharp',


### PR DESCRIPTION
Same as this PR: 

https://github.com/gocardless/enterprise-api-docs/pull/212
