### PR TITLE
Fix broken link to official libraries

### DIFF
--- a/source/docs/05_webhooks_http/03_response.http.md
+++ b/source/docs/05_webhooks_http/03_response.http.md
@@ -2,7 +2,7 @@
 
 Your server should validate the HMAC digest by resigning the contents of the payload object, not including the container payload itself, and respond with status `HTTP/1.1 200 OK` within 5 seconds.
 
-For more information about generating a signature see [Signing Requests](#signing-requests) in the Connect Guide. The GoCardless [client libraries](official-libraries) each handle signing requests; if you are building an integration without a client library, check their source code for a reference implementation.
+For more information about generating a signature see [Signing Requests](#signing-requests) in the Connect Guide. The GoCardless [client libraries](#official-libraries) each handle signing requests; if you are building an integration without a client library, check their source code for a reference implementation.
 
 If the API server does not get a 200 OK response within 5 seconds, it will retry up to 10 times at ever-increasing time intervals. If you have time-consuming server-side processes that are triggered by a webhook please consider processing them asynchronously.
 


### PR DESCRIPTION
Hey @jacobpgn 

Managed to fix one broken link (official-libraries --> #official-libraries) - though couldn't work out how to fix the other one.

Looks like Markdown automatically translates `http://[your domain]/gocardless/confirm` into a broken link going to `http://[your/`

The broken link is found on four pages:
* https://developer.gocardless.com/ruby/
* https://developer.gocardless.com/python/
* https://developer.gocardless.com/php/
* https://developer.gocardless.com/node/

There's also a broken e-mail link on https://developer.gocardless.com/pro/ - not quite sure how to fix this?  You can find it on: "We are actively seeking feedback on this API so please **contact us** with any suggestions."
