### PR TITLE
set environment in python docs

### DIFF
--- a/source/docs/02_api_libraries/02_initialization/01_initialization.py.md
+++ b/source/docs/02_api_libraries/02_initialization/01_initialization.py.md
@@ -4,6 +4,7 @@ After [installing the GoCardless Python library](#installation), you will need t
 
 ```python
 import gocardless
+gocardless.environment = 'sandbox'
 gocardless.set_details(app_id="DUMMY_APP",
         app_secret="INSERT_APP_SECRET_HERE",
         access_token="INSERT_MERCHANT_ACCESS_TOKEN",

--- a/source/docs/02_api_libraries/02_initialization/01_initialization.py.md
+++ b/source/docs/02_api_libraries/02_initialization/01_initialization.py.md
@@ -10,6 +10,9 @@ gocardless.set_details(app_id="DUMMY_APP",
         access_token="INSERT_MERCHANT_ACCESS_TOKEN",
         merchant_id="INSERT_MERCHANT_ID")
 ```
+By default the library will attempt to use the GoCardless production environment, for testing purposes this is not what you want and you should set the gocardless.environment to "sandbox":
+
+`gocardless.environment = "sandbox"`
 
 You should now be able to make requests to the GoCardless library.
 

--- a/source/docs/02_api_libraries/02_initialization/01_initialization.py.md
+++ b/source/docs/02_api_libraries/02_initialization/01_initialization.py.md
@@ -4,7 +4,6 @@ After [installing the GoCardless Python library](#installation), you will need t
 
 ```python
 import gocardless
-gocardless.environment = 'sandbox'
 gocardless.set_details(app_id="DUMMY_APP",
         app_secret="INSERT_APP_SECRET_HERE",
         access_token="INSERT_MERCHANT_ACCESS_TOKEN",


### PR DESCRIPTION
# Problem
It's not made clear that if you are using your sandbox credentials, you will receive the following error: `gocardless.exceptions.ClientError: Error calling api, message was Unauthorized`

# Solution
Explicitly setting the gocardless environment 👍 